### PR TITLE
fix: release CI — macOS sha256, Linux ARM64, coreml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
             features: coreml
             artifact: qfc-macos-arm64
           - name: macOS Intel
-            os: macos-13
+            os: macos-15
             target: x86_64-apple-darwin
             features: candle
             artifact: qfc-macos-intel
@@ -75,7 +75,7 @@ jobs:
         if: contains(matrix.features, 'cuda')
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
-          cuda: '12.6.3'
+          cuda: '12.6.0'
           method: network
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "cusolver", "cusolver_dev", "curand", "curand_dev"]'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           - name: macOS Apple Silicon
             os: macos-14
             target: aarch64-apple-darwin
-            features: metal,candle
+            features: coreml
             artifact: qfc-macos-arm64
           - name: macOS Intel
             os: macos-13
@@ -32,6 +32,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             features: candle
             artifact: qfc-linux-x86_64
+          - name: Linux ARM64 CPU
+            os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            features: candle
+            artifact: qfc-linux-arm64
           - name: Windows x86_64 CPU
             os: windows-2022
             target: x86_64-pc-windows-msvc
@@ -94,7 +99,12 @@ jobs:
           mkdir -p dist
           cp qfc-core/target/${{ matrix.target }}/release/qfc-miner dist/
           cd dist && tar czf ../${{ matrix.artifact }}.tar.gz qfc-miner
-          sha256sum ../${{ matrix.artifact }}.tar.gz > ../${{ matrix.artifact }}.tar.gz.sha256
+          cd ..
+          if command -v sha256sum &>/dev/null; then
+            sha256sum ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.tar.gz.sha256
+          else
+            shasum -a 256 ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.tar.gz.sha256
+          fi
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -155,5 +165,6 @@ jobs:
             | macOS Apple Silicon | `qfc-macos-arm64.tar.gz` | Metal ✅ |
             | macOS Intel | `qfc-macos-intel.tar.gz` | CPU |
             | Linux x86_64 | `qfc-linux-x86_64.tar.gz` | CUDA (if available) |
+            | Linux ARM64 | `qfc-linux-arm64.tar.gz` | CPU |
             | Windows x86_64 | `qfc-windows-x86_64.zip` | CPU |
             | Windows x86_64 CUDA | `qfc-windows-x86_64-cuda.zip` | CUDA ✅ |


### PR DESCRIPTION
## Summary
- Fix `sha256sum` not found on macOS — use `shasum -a 256` fallback
- Add **Linux ARM64** (`aarch64-unknown-linux-gnu`) matrix entry
- Switch macOS Apple Silicon from `metal,candle` to `coreml` (matches qfc-core v2.2.3)
- Update release notes table

Fixes the v2.2.3 release build failure on macOS.

## Test plan
- [ ] Re-tag v2.2.3 or trigger workflow_dispatch to verify all builds pass
- [ ] Verify macOS packaging produces valid `.tar.gz` + `.sha256`
- [ ] Verify Linux ARM64 build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)