### PR TITLE
fix(onboarding): correct install.ps1 release repo + binary↔chain version-drift warning (2A.1)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -22,7 +22,9 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$GITHUB_REPO = "qfc-network/qfc-core"
+# Pre-built Windows binaries are published on qfc-miner releases (9 platforms),
+# not qfc-core (fewer, older). Override with $env:QFC_BINARIES_REPO if needed.
+$GITHUB_REPO = if ($env:QFC_BINARIES_REPO) { $env:QFC_BINARIES_REPO } else { "qfc-network/qfc-miner" }
 $INSTALL_DIR = "$env:USERPROFILE\.qfc-miner"
 $WALLET_FILE = "$INSTALL_DIR\wallet.json"
 $RPC_URL     = if ($env:QFC_MINER_RPC_URL) { $env:QFC_MINER_RPC_URL } else { "https://rpc.testnet.qfc.network" }
@@ -155,6 +157,28 @@ if ($needInstall) {
         }
     }
 }
+
+# --- Step 2b: Warn if binary and chain versions have drifted apart ---
+function Check-ChainCompat {
+    $binTag = if (Test-Path $VERSION_FILE) { (Get-Content $VERSION_FILE | Select-Object -First 1).Trim() } else { "" }
+    if (-not $binTag) { return }
+    try {
+        $body = '{"jsonrpc":"2.0","method":"qfc_nodeInfo","params":[],"id":1}'
+        $resp = Invoke-RestMethod $RPC_URL -Method Post -Body $body -ContentType "application/json" -TimeoutSec 10
+        $chainVer = $resp.result.version
+    } catch { return }  # RPC unreachable — not fatal for install
+    if (-not $chainVer) { return }
+    $binMM   = ($binTag.TrimStart("v").Split(".") | Select-Object -First 2) -join "."
+    $chainMM = ($chainVer.Split(".") | Select-Object -First 2) -join "."
+    if ($binMM -ne $chainMM) {
+        Warn "Version drift: miner binary $binTag vs chain node v$chainVer."
+        Warn "Proofs may be rejected if the protocol changed between these versions."
+        Warn "Check https://github.com/$GITHUB_REPO/releases for a release matching the chain."
+    } else {
+        Ok "Binary $binTag matches chain v$chainVer (major.minor)"
+    }
+}
+Check-ChainCompat
 
 # --- Step 3: Generate wallet ---
 if (Test-Path $WALLET_FILE) {

--- a/scripts/start-miner.sh
+++ b/scripts/start-miner.sh
@@ -309,6 +309,32 @@ else
     [[ -n "${INIT_VER:-}" ]] && echo "$INIT_VER" > "$INSTALL_DIR/.version"
 fi
 
+# --- Step 2b: Warn if binary and chain versions have drifted apart ---
+check_chain_compat() {
+    local BIN_TAG=""
+    [[ -f "$INSTALL_DIR/.version" ]] && BIN_TAG=$(head -1 "$INSTALL_DIR/.version" 2>/dev/null)
+    [[ -n "$BIN_TAG" ]] || return 0
+
+    local CHAIN_VER
+    CHAIN_VER=$(curl -sf -m 10 "$RPC_URL" -X POST -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","method":"qfc_nodeInfo","params":[],"id":1}' 2>/dev/null \
+        | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4) || true
+    [[ -n "${CHAIN_VER:-}" ]] || return 0   # RPC unreachable — not fatal for install
+
+    local BIN_MM CHAIN_MM
+    BIN_MM=$(echo "${BIN_TAG#v}" | cut -d. -f1-2)
+    CHAIN_MM=$(echo "$CHAIN_VER" | cut -d. -f1-2)
+
+    if [[ "$BIN_MM" != "$CHAIN_MM" ]]; then
+        warn "Version drift: miner binary $BIN_TAG vs chain node v$CHAIN_VER."
+        warn "Proofs may be rejected if the protocol changed between these versions."
+        warn "Check https://github.com/$BINARIES_REPO/releases for a release matching the chain."
+    else
+        ok "Binary $BIN_TAG matches chain v$CHAIN_VER (major.minor)"
+    fi
+}
+check_chain_compat
+
 # --- Step 3: Generate wallet (if needed) ---
 if [[ -f "$WALLET_FILE" ]]; then
     ADDR=$(grep '"address"' "$WALLET_FILE" | cut -d'"' -f4)


### PR DESCRIPTION
## Summary
The two onboarding bugs from qfc-design `miner-economics/MINER-ONBOARDING-REVIEW.md` (2A.1 in 44-L1-MASTER-PLAN):

**Bug ① — Windows remnant of the release-repo mismatch.** `start-miner.sh` was already fixed to default to `qfc-network/qfc-miner`, but `install.ps1` still downloaded from `qfc-network/qfc-core` — Windows CUDA users would miss the dedicated 9-platform assets. Now defaults to `qfc-network/qfc-miner` with a `$env:QFC_BINARIES_REPO` override, matching the bash script's convention.

**Bug ② — version drift was invisible.** Both scripts now compare the installed release tag against the chain's `qfc_nodeInfo.version` (major.minor) after install and print a warning with a pointer to the releases page. Non-fatal; skips silently when RPC is unreachable so offline installs still work.

## Verification
- `bash -n` clean.
- Drift check run against the live testnet RPC: correctly warns on the **real, currently-existing drift** (binary v2.3.2 vs chain v2.2.3).
- pwsh unavailable on this machine — install.ps1 change is minimal (repo constant + one function mirroring the bash logic); flagging for a Windows smoke test during the 2A.2 clean-install pass.

## Notes
- Full end-to-end onboarding verification (clean VPS → proof visible on explorer) is deliberately deferred to **2A.2 after the consensus fix + testnet reset** — the chain is currently forked, so proofs land on divergent branches and verify nothing.
- `qfc-miner` binary has no `--version` flag (clap `version` attr unset in qfc-core `crates/qfc-miner/src/config.rs:10`) — worth adding in the next qfc-core release so the check can use the binary's own version instead of the saved tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)